### PR TITLE
Refactor/time based retention

### DIFF
--- a/tests/artifactory/test_artifactory.py
+++ b/tests/artifactory/test_artifactory.py
@@ -7,6 +7,7 @@ from lavatory.utils.artifactory import Artifactory
 
 TEST_PROPS = {'build': 1, 'other': 'test'}
 
+
 @pytest.fixture
 @mock.patch('lavatory.utils.artifactory.load_credentials')
 @mock.patch('lavatory.utils.artifactory.party.Party.request')
@@ -22,18 +23,15 @@ def artifactory(mock_party, mock_credentials):
     artifactory.artifactory.properties = TEST_PROPS
     return artifactory
 
+
 @mock.patch('lavatory.utils.artifactory.party.Party.request')
 def test_list(mock_party_request, artifactory):
-    data = {
-        'repositoriesSummaryList': [{
-            'repoKey': 'test-local',
-            'repoType': 'LOCAL'
-        }]
-    }
+    data = {'repositoriesSummaryList': [{'repoKey': 'test-local', 'repoType': 'LOCAL'}]}
     mock_party_request.return_value.json.return_value = data
     art = artifactory.list()
 
     assert art['test-local'] == {'repoKey': 'test-local', 'repoType': 'LOCAL'}
+
 
 @mock.patch('lavatory.utils.artifactory.party.Party.get_properties')
 def test_get_artifact_properties(mock_properties, artifactory):

--- a/tests/artifactory/test_artifactory.py
+++ b/tests/artifactory/test_artifactory.py
@@ -1,25 +1,42 @@
 """Unit tests for Artifactory Module."""
 
+import pytest
 from unittest import mock
+
 from lavatory.utils.artifactory import Artifactory
 
+TEST_PROPS = {'build': 1, 'other': 'test'}
 
-@mock.patch('lavatory.utils.artifactory.party.Party.get')
+@pytest.fixture
 @mock.patch('lavatory.utils.artifactory.load_credentials')
-def test_list(mock_load_credentials, mock_party_request):
-    credentials = {'artifactory_password': 'test_password',
-                   'artifactory_url': 'test_url',
-                   'artifactory_username': 'test_username'}
+@mock.patch('lavatory.utils.artifactory.party.Party.request')
+def artifactory(mock_party, mock_credentials):
+    creds = {
+        'artifactory_password': 'test_password',
+        'artifactory_url': 'test_url',
+        'artifactory_username': 'test_username'
+    }
+
+    mock_credentials.return_value = creds
+    artifactory = Artifactory()
+    artifactory.artifactory.properties = TEST_PROPS
+    return artifactory
+
+@mock.patch('lavatory.utils.artifactory.party.Party.request')
+def test_list(mock_party_request, artifactory):
     data = {
         'repositoriesSummaryList': [{
             'repoKey': 'test-local',
             'repoType': 'LOCAL'
         }]
     }
-    mock_load_credentials.return_value = credentials
     mock_party_request.return_value.json.return_value = data
-
-    repos = Artifactory()
-    art = repos.list()
+    art = artifactory.list()
 
     assert art['test-local'] == {'repoKey': 'test-local', 'repoType': 'LOCAL'}
+
+@mock.patch('lavatory.utils.artifactory.party.Party.get_properties')
+def test_get_artifact_properties(mock_properties, artifactory):
+    test_artifact = {"name": "test", "path": "path/to/test"}
+    props = artifactory.get_artifact_properties(test_artifact)
+    assert props == TEST_PROPS

--- a/tests/artifactory/test_retention_functions.py
+++ b/tests/artifactory/test_retention_functions.py
@@ -5,7 +5,6 @@ from unittest import mock
 
 from lavatory.utils.artifactory import Artifactory
 
-TEST_PROPS = {'build': 1, 'other': 'test'}
 TEST_ARTIFACT1 = {'name': 'test1', 'path': '/path/to/test/1'}
 TEST_ARTIFACT2 = {'name': 'test2', 'path': '/path/to/test/2'}
 
@@ -22,7 +21,6 @@ def artifactory(mock_party, mock_credentials):
 
     mock_credentials.return_value = creds
     artifactory = Artifactory()
-    artifactory.artifactory.properties = TEST_PROPS
     return artifactory
 
 
@@ -48,3 +46,15 @@ def test_count_based_retention(mock_find_aql, artifactory):
     expected_return = [TEST_ARTIFACT1, TEST_ARTIFACT1, TEST_ARTIFACT2, TEST_ARTIFACT2]
     purgable = artifactory.count_based_retention(retention_count=1)
     assert purgable == expected_return
+
+@mock.patch('lavatory.utils.artifactory.party.Party.find_by_aql')
+def test_time_based_retention(mock_find_aql, artifactory):
+    """Tests count base retention returns sorted values"""
+    test_artifacts = {'results': [TEST_ARTIFACT2, TEST_ARTIFACT1]}
+    mock_find_aql.return_value = test_artifacts
+
+    # deplicates values because of nested search at project level. Expected
+    expected_return = [TEST_ARTIFACT1, TEST_ARTIFACT1, TEST_ARTIFACT2, TEST_ARTIFACT2]
+    purgable = artifactory.count_time_retention(keep_days=10)
+    assert purgable == expected_return
+

--- a/tests/artifactory/test_retention_functions.py
+++ b/tests/artifactory/test_retention_functions.py
@@ -6,6 +6,8 @@ from unittest import mock
 from lavatory.utils.artifactory import Artifactory
 
 TEST_PROPS = {'build': 1, 'other': 'test'}
+TEST_ARTIFACT1 = {'name': 'test1', 'path': '/path/to/test/1'}
+TEST_ARTIFACT2 = {'name': 'test2', 'path': '/path/to/test/2'}
 
 
 @pytest.fixture
@@ -28,24 +30,10 @@ def artifactory(mock_party, mock_credentials):
 @mock.patch('lavatory.utils.artifactory.party.Party.get_properties')
 def test_get_all_artifacts(mock_properties, mock_find_aql, artifactory):
     """Tests get_all_repo_artifacts returns all artifacts sorted"""
-    test_artifacts = {
-        'results': [{
-            'name': 'test2',
-            'path': '/path/to/test/2'
-        }, {
-            'name': 'test1',
-            'path': '/path/to/test/1'
-        }]
-    }
+    test_artifacts = {'results': [TEST_ARTIFACT2, TEST_ARTIFACT1]}
     mock_find_aql.return_value = test_artifacts
 
-    expected_return = [{
-        'name': 'test1',
-        'path': '/path/to/test/1'
-    }, {
-        'name': 'test2',
-        'path': '/path/to/test/2'
-    }]
+    expected_return = [TEST_ARTIFACT1, TEST_ARTIFACT2]
     artifacts = artifactory.get_all_repo_artifacts()
     assert artifacts == expected_return
 
@@ -53,37 +41,10 @@ def test_get_all_artifacts(mock_properties, mock_find_aql, artifactory):
 @mock.patch('lavatory.utils.artifactory.party.Party.find_by_aql')
 def test_count_based_retention(mock_find_aql, artifactory):
     """Tests count base retention returns sorted values"""
-    test_artifacts = {
-        'results': [{
-            'name': 'test2',
-            'path': '/path/to/test/2'
-        }, {
-            'name': 'test1',
-            'path': '/path/to/test/1'
-        }]
-    }
+    test_artifacts = {'results': [TEST_ARTIFACT2, TEST_ARTIFACT1]}
     mock_find_aql.return_value = test_artifacts
 
     # deplicates values because of nested search at project level. Expected
-    expected_return = [{
-        'name': 'test1',
-        'path': '/path/to/test/1'
-    }, {
-        'name': 'test1',
-        'path': '/path/to/test/1'
-    }, {
-        'name': 'test2',
-        'path': '/path/to/test/2'
-    }, {
-        'name': 'test2',
-        'path': '/path/to/test/2'
-    }]
+    expected_return = [TEST_ARTIFACT1, TEST_ARTIFACT1, TEST_ARTIFACT2, TEST_ARTIFACT2]
     purgable = artifactory.count_based_retention(retention_count=1)
     assert purgable == expected_return
-
-
-@mock.patch('lavatory.utils.artifactory.party.Party.get_properties')
-def test_get_artifact_properties(mock_properties, artifactory):
-    test_artifact = {"name": "test", "path": "path/to/test"}
-    props = artifactory.get_artifact_properties(test_artifact)
-    assert props == TEST_PROPS

--- a/tests/artifactory/test_retention_functions.py
+++ b/tests/artifactory/test_retention_functions.py
@@ -47,14 +47,13 @@ def test_count_based_retention(mock_find_aql, artifactory):
     purgable = artifactory.count_based_retention(retention_count=1)
     assert purgable == expected_return
 
+
 @mock.patch('lavatory.utils.artifactory.party.Party.find_by_aql')
 def test_time_based_retention(mock_find_aql, artifactory):
     """Tests count base retention returns sorted values"""
     test_artifacts = {'results': [TEST_ARTIFACT2, TEST_ARTIFACT1]}
     mock_find_aql.return_value = test_artifacts
 
-    # deplicates values because of nested search at project level. Expected
-    expected_return = [TEST_ARTIFACT1, TEST_ARTIFACT1, TEST_ARTIFACT2, TEST_ARTIFACT2]
-    purgable = artifactory.count_time_retention(keep_days=10)
+    expected_return = [TEST_ARTIFACT1, TEST_ARTIFACT2]
+    purgable = artifactory.time_based_retention(keep_days=10)
     assert purgable == expected_return
-


### PR DESCRIPTION
This adds time based retention with the ability to add extra AQL. So the plugin could look like:

```
def purgelist(artifactory):
    extra_aql = [{"@deployed": {"$match": "dev"}}, {"@deployed": {"$nmatch": "prod"}}]
    purgable = artifactory.time_based_retention(keep_days=120, extra_aql=extra_aql)
    return purgable
```

I tried to abstract out the AQL for a while but it just got more and more complicated. Adding raw AQL terms like this is the cleanest way if you want to do this against specific properties