### PR TITLE
Feature/specific repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,14 @@ Purging Artifacts
       --dryrun / --nodryrun     Dryrun does not delete any artifacts. On by
                                 default
       --default / --no-default  If false, does not apply default policy
+      --repo TEXT               Name of specific repository to run against. Can
+                                use --repo multiple times. If not provided, uses
+                                all repos.
       --help                    Show this message and exit.
+
+If you want to run Lavatory against a specific repository, you can use ``--repo <repo_name>``.
+You can specify ``--repo`` as multiple times to run against multiple repos. If ``--repo`` is not
+provided, Lavatory will run against all repos in Artifactory.  
 
 Testing
 ~~~~~~~

--- a/src/lavatory/commands/purge.py
+++ b/src/lavatory/commands/purge.py
@@ -22,12 +22,13 @@ def purge(ctx, dryrun, policies_path, default, repo):
     artifactory = Artifactory(repo_name=None)
     plugin_source = setup_pluginbase(extra_policies_path=policies_path)
 
+    before_repo_data = artifactory.list()
     if repo:
         all_repos = repo
     else:
-        all_repos = artifactory.list()
-        return
-
+        all_repos = before_repo_data.keys()
+    
+    LOG.info("Applying retention policies to %s", ', '.join(all_repos))
     for repo in all_repos:
         policy_name = repo.replace("-", "_")
         artifactory_repo = Artifactory(repo_name=repo)
@@ -48,11 +49,12 @@ def purge(ctx, dryrun, policies_path, default, repo):
 
     LOG.info("")
     LOG.info("Purging Performance:")
-    after = artifactory.list()
-    for repo, info in after.items():
-        try:
-            get_performance_report(repo, before[repo], info)
-        except IndexError:
-            pass
+    after_repo_data = artifactory.list()
+    for repo, info in after_repo_data.items():
+        if repo in all_repos:
+            try:
+                get_performance_report(repo, before_repo_data[repo], info)
+            except IndexError:
+                pass
 
     LOG.info("Done.")

--- a/src/lavatory/commands/purge.py
+++ b/src/lavatory/commands/purge.py
@@ -15,13 +15,20 @@ LOG = logging.getLogger(__name__)
 @click.option(
     '--dryrun/--nodryrun', default=True, is_flag=True, help='Dryrun does not delete any artifacts. On by default')
 @click.option('--default/--no-default', default=True, is_flag=True, help='If false, does not apply default policy')
-def purge(ctx, dryrun, policies_path, default):
+@click.option('--repo', default=None, multiple=True, required=False, 
+              help='Name of specific repository to run against. Can use --repo multiple times. If not provided, uses all repos.')
+def purge(ctx, dryrun, policies_path, default, repo):
     """Deletes artifacts based on retention policies"""
     artifactory = Artifactory(repo_name=None)
-
     plugin_source = setup_pluginbase(extra_policies_path=policies_path)
-    before = artifactory.list()
-    for repo, info in before.items():
+
+    if repo:
+        all_repos = repo
+    else:
+        all_repos = artifactory.list()
+        return
+
+    for repo in all_repos:
         policy_name = repo.replace("-", "_")
         artifactory_repo = Artifactory(repo_name=repo)
         try:


### PR DESCRIPTION
Added the ability to specify repos on the CLI if you want to only check a couple:

Looks like `lavatory purge --repo docker-local --repo vagrant-iteration`

You can add as many `--repo` as you want. If none provided, runs against all repos. 