### PR TITLE
refactor: Rename method so its more descriptive

### DIFF
--- a/src/lavatory/commands/purge.py
+++ b/src/lavatory/commands/purge.py
@@ -48,7 +48,7 @@ def purge(ctx, dryrun, policies_path, default, repo, repo_type):
 
 
 def apply_purge_policies(selected_repos, policies_path=None, dryrun=True, default=True):
-    """Sets up the plugins to find purgable artifacts and delete them. 
+    """Sets up the plugins to find purgable artifacts and delete them.
 
     Args:
         selected_repos (list): List of repos to run against.
@@ -78,7 +78,7 @@ def generate_purge_report(purged_repos, before_purge_data):
     """
     LOG.info("Purging Performance:")
     artifactory = Artifactory(repo_name=None)
-    after_purge_data = artifactory.list()
+    after_purge_data = artifactory.repos()
 
     for repo, info in after_purge_data.items():
         if repo in purged_repos:

--- a/src/lavatory/utils/artifactory.py
+++ b/src/lavatory/utils/artifactory.py
@@ -29,7 +29,7 @@ class Artifactory(object):
         self.artifactory.password = base64.encodebytes(bytes(self.credentials['artifactory_password'], 'utf-8'))
         self.artifactory.certbundle = certifi.where()
 
-    def list(self, repo_type='local'):
+    def repos(self, repo_type='local'):
         """
         Return a dictionary of repos with basic info about each.
 

--- a/src/lavatory/utils/get_artifactory_info.py
+++ b/src/lavatory/utils/get_artifactory_info.py
@@ -16,7 +16,7 @@ def get_artifactory_info(repo_names=None, repo_type='local'):
          storage_info (dict): Storage information api call.
     """
     artifactory = Artifactory(repo_name=repo_names)
-    storage_info = artifactory.list(repo_type=repo_type)
+    storage_info = artifactory.repos(repo_type=repo_type)
 
     if repo_names:
         keys = repo_names

--- a/tests/artifactory/test_artifactory.py
+++ b/tests/artifactory/test_artifactory.py
@@ -28,7 +28,7 @@ def artifactory(mock_party, mock_credentials):
 def test_list(mock_party_request, artifactory):
     data = {'repositoriesSummaryList': [{'repoKey': 'test-local', 'repoType': 'LOCAL'}]}
     mock_party_request.return_value.json.return_value = data
-    art = artifactory.list()
+    art = artifactory.repos()
 
     assert art['test-local'] == {'repoKey': 'test-local', 'repoType': 'LOCAL'}
 
@@ -46,4 +46,3 @@ def test_move_artifacts(artifactory):
     moved = artifactory.move_artifacts(artifacts=test_artifacts,
                                        dest_repository='test_repo')
     assert moved
-

--- a/tests/artifactory/test_get_artifactory_info.py
+++ b/tests/artifactory/test_get_artifactory_info.py
@@ -6,7 +6,7 @@ from lavatory.utils.get_artifactory_info import get_artifactory_info
 @mock.patch('lavatory.utils.get_artifactory_info.Artifactory')
 def test_list(mock_artifactory):
     data = {'test-local': {'repoKey': 'test-local', 'repoType': 'LOCAL'}}
-    mock_artifactory.return_value.list.return_value = data
+    mock_artifactory.return_value.repos.return_value = data
 
     storage_list, keys = get_artifactory_info()
 

--- a/tests/commands/test_purge.py
+++ b/tests/commands/test_purge.py
@@ -20,7 +20,7 @@ def test_apply_purge_policies(mock_artifactory):
 @mock.patch('lavatory.commands.purge.Artifactory')
 def test_purge_report(mock_artifactory):
     """Unit test for purge report"""
-    mock_artifactory.list.return_value = {"yum-local": "", "test_local": ""}
+    mock_artifactory.repos.return_value = {"yum-local": "", "test_local": ""}
     purged_repos = ['yum-local', 'test_local']
     before_data = {"yum-local": ""}
     report = generate_purge_report(purged_repos, before_data)
@@ -57,5 +57,3 @@ def test_policies(mock_purge_report, mock_purge_policies, mock_get_art_info, run
 
     assert result_one.exit_code == 0
     assert result_one.output == ''
-
-


### PR DESCRIPTION
The method name `list()` doesn't describe what it does or must less returns.

I thought renaming it to `repos()` made better sense as to what it does and/or returns.