### PR TITLE
moved sorting into the move and purge functions

### DIFF
--- a/docs/policies/example_policies.rst
+++ b/docs/policies/example_policies.rst
@@ -27,8 +27,8 @@ Keep artifacts downloaded in the last 60 days
 
     def purgelist(artifactory):
         """Policy to purge all artifacts not downloaded in last 60 days"""
-        purgable = artifactory.time_based_retention(keep_days=60, time_field='stat.downloaded')
-        return purgable
+        purgeable = artifactory.time_based_retention(keep_days=60, time_field='stat.downloaded')
+        return purgeable
 
 
 Keep 5 most recent artifacts
@@ -38,8 +38,8 @@ Keep 5 most recent artifacts
 
     def purgelist(artifactory):
         """Policy to keep just the 5 most recent artifacts."""
-        purgable = artifactory.count_based_retention(retention_count=5)
-        return purgable
+        purgeable = artifactory.count_based_retention(retention_count=5)
+        return purgeable
 
 
 Keep artifacts with specific properties
@@ -51,8 +51,8 @@ Keep artifacts with specific properties
         """Policy to purge artifacts with deployed property of dev and not prod."""
         aql_terms = [{"@deployed": {"$match": "dev"}}, {"@deployed": {"$nmatch": "prod"}}]
         extra_fields = ['property.*']
-        purgable = artifactory.filter(terms=aql_terms, fields=extra_fields, depth=None, item_type="any")
-        return purgable
+        purgeable = artifactory.filter(terms=aql_terms, fields=extra_fields, depth=None, item_type="any")
+        return purgeable
 
 Keep all artifacts
 ------------------
@@ -92,7 +92,7 @@ More complicated examples
                     ]
         purgeable = artifactory.filter(terms=docker_terms, depth=None, item_type="file")
 
-        return sorted(purgeable, key=lambda k: k['path'])
+        return purgeable
 
 ::
 
@@ -117,5 +117,5 @@ More complicated examples
         only_dev_purgeable = artifactory.time_based_retention(keep_days=21, extra_aql=only_dev)
         only_stage_purgeable = artifactory.time_based_retention(keep_days=30, extra_aql=only_dev)
 
-        all_purgable = undeployed_purgeable + only_dev_purgeable + only_stage_purgeable
-        return sorted(all_purgable, key=lambda k: k['path'])
+        all_purgeable = undeployed_purgeable + only_dev_purgeable + only_stage_purgeable
+        return all_purgeable

--- a/tests/artifactory/test_retention_functions.py
+++ b/tests/artifactory/test_retention_functions.py
@@ -27,33 +27,33 @@ def artifactory(mock_party, mock_credentials):
 @mock.patch('lavatory.utils.artifactory.party.Party.find_by_aql')
 @mock.patch('lavatory.utils.artifactory.party.Party.get_properties')
 def test_get_all_artifacts(mock_properties, mock_find_aql, artifactory):
-    """Tests get_all_repo_artifacts returns all artifacts sorted"""
+    """Tests get_all_repo_artifacts returns all artifacts."""
     test_artifacts = {'results': [TEST_ARTIFACT2, TEST_ARTIFACT1]}
     mock_find_aql.return_value = test_artifacts
 
-    expected_return = [TEST_ARTIFACT1, TEST_ARTIFACT2]
+    expected_return = [TEST_ARTIFACT2, TEST_ARTIFACT1]
     artifacts = artifactory.get_all_repo_artifacts()
     assert artifacts == expected_return
 
 
 @mock.patch('lavatory.utils.artifactory.party.Party.find_by_aql')
 def test_count_based_retention(mock_find_aql, artifactory):
-    """Tests count base retention returns sorted values"""
+    """Tests count base retention returns values"""
     test_artifacts = {'results': [TEST_ARTIFACT2, TEST_ARTIFACT1]}
     mock_find_aql.return_value = test_artifacts
 
     # deplicates values because of nested search at project level. Expected
-    expected_return = [TEST_ARTIFACT1, TEST_ARTIFACT1, TEST_ARTIFACT2, TEST_ARTIFACT2]
+    expected_return = [TEST_ARTIFACT2, TEST_ARTIFACT1, TEST_ARTIFACT2, TEST_ARTIFACT1]
     purgable = artifactory.count_based_retention(retention_count=1)
     assert purgable == expected_return
 
 
 @mock.patch('lavatory.utils.artifactory.party.Party.find_by_aql')
 def test_time_based_retention(mock_find_aql, artifactory):
-    """Tests count base retention returns sorted values"""
+    """Tests count base retention returns values"""
     test_artifacts = {'results': [TEST_ARTIFACT2, TEST_ARTIFACT1]}
     mock_find_aql.return_value = test_artifacts
 
-    expected_return = [TEST_ARTIFACT1, TEST_ARTIFACT2]
+    expected_return = [TEST_ARTIFACT2, TEST_ARTIFACT1]
     purgable = artifactory.time_based_retention(keep_days=10)
     assert purgable == expected_return


### PR DESCRIPTION
The sorting is only used for logs, it makes it much easier to group what is going to be moved/deleted.

This makes it so you never need to sort in a policy. 

also fixes all my mispellings of "purgeable"

closes #25 