### PR TITLE
Display full path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ cache: false
 
 matrix:
   include:
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,8 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
     ],

--- a/src/lavatory/utils/setup_pluginbase.py
+++ b/src/lavatory/utils/setup_pluginbase.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import pathlib
 
 from pluginbase import PluginBase
@@ -23,10 +24,12 @@ def setup_pluginbase(extra_policies_path=None):
 
     all_paths = [default_path]
     if extra_policies_path:
-        extra_policies = pathlib.Path(extra_policies_path).expanduser().resolve()
-        if not extra_policies.is_dir():
+        extra_policies_obj = pathlib.Path(extra_policies_path)
+        if extra_policies_obj.is_dir():
+            extra_policies = get_directory_path(extra_policies_obj)
+            all_paths.insert(0, str(extra_policies))
+        else:
             raise InvalidPoliciesDirectory
-        all_paths.insert(0, str(extra_policies))
     LOG.info("Searching for policies in %s", str(all_paths))
     plugin_base = PluginBase(package='lavatory.policy_plugins')
     plugin_source = plugin_base.make_plugin_source(searchpath=all_paths)
@@ -56,3 +59,20 @@ def get_policy(plugin_source, repository, default=True):
             LOG.info("No policy found for %s. Skipping Default", repository)
             policy = None
     return policy
+
+
+def get_directory_path(directory):
+    """Gets policy from plugin_source.
+
+    Args:
+        directory (Path): Directory path
+
+    Returns:
+        full_path (Path): The full expanded directory path
+    """
+    full_path = ''
+    if hasattr(directory, 'expanduser'):
+        full_path = directory.expanduser().resolve()
+    else:
+        full_path = pathlib.Path(os.path.expanduser(directory)).resolve()
+    return full_path

--- a/src/lavatory/utils/setup_pluginbase.py
+++ b/src/lavatory/utils/setup_pluginbase.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import pathlib
 
 from pluginbase import PluginBase
@@ -24,9 +23,10 @@ def setup_pluginbase(extra_policies_path=None):
 
     all_paths = []
     if extra_policies_path:
-        if not os.path.isdir(extra_policies_path):
+        extra_policies = pathlib.Path(extra_policies_path).expanduser().resolve()
+        if not extra_policies.is_dir():
             raise InvalidPoliciesDirectory
-        all_paths.append(extra_policies_path)
+        all_paths.append(str(extra_policies))
     all_paths.append(default_path)
     LOG.info("Searching for policies in %s", str(all_paths))
     plugin_base = PluginBase(package='lavatory.policy_plugins')

--- a/src/lavatory/utils/setup_pluginbase.py
+++ b/src/lavatory/utils/setup_pluginbase.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pathlib
 
 from pluginbase import PluginBase
 
@@ -17,8 +18,10 @@ def setup_pluginbase(extra_policies_path=None):
     Returns:
         PluginSource: PluginBase PluginSource for finding plugins
     """
-    here = os.path.dirname(os.path.realpath(__file__))
-    default_path = "{}/../policies".format(here)
+    here = pathlib.Path(__file__).parent.absolute()
+    default_path_obj = here / "../policies"
+    default_path = str(default_path_obj.resolve())
+
     all_paths = []
     if extra_policies_path:
         if not os.path.isdir(extra_policies_path):

--- a/src/lavatory/utils/setup_pluginbase.py
+++ b/src/lavatory/utils/setup_pluginbase.py
@@ -21,13 +21,12 @@ def setup_pluginbase(extra_policies_path=None):
     default_path_obj = here / "../policies"
     default_path = str(default_path_obj.resolve())
 
-    all_paths = []
+    all_paths = [default_path]
     if extra_policies_path:
         extra_policies = pathlib.Path(extra_policies_path).expanduser().resolve()
         if not extra_policies.is_dir():
             raise InvalidPoliciesDirectory
-        all_paths.append(str(extra_policies))
-    all_paths.append(default_path)
+        all_paths.insert(0, str(extra_policies))
     LOG.info("Searching for policies in %s", str(all_paths))
     plugin_base = PluginBase(package='lavatory.policy_plugins')
     plugin_source = plugin_base.make_plugin_source(searchpath=all_paths)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36,lint
+envlist = py35,py36,lint
 skip_missing_interpreters = True
 
 [pytest]


### PR DESCRIPTION
This makes updates so that the output is the full path of the plugin directory.

```
# Old
[INFO] lavatory.utils.setup_pluginbase Searching for policies in ['/home/sijis/git/github/lavatory/src/lavatory/utils/../policies']

# New
[INFO] lavatory.utils.setup_pluginbase Searching for policies in ['/home/sijis/git/github/lavatory/src/lavatory/policies']
```

These changes will also also handle if `~` is passed to `--policies-path` parameter.