### PR TITLE
Gracefully proceed when user is not admin

### DIFF
--- a/src/lavatory/commands/policies.py
+++ b/src/lavatory/commands/policies.py
@@ -6,7 +6,7 @@ import logging
 import click
 
 from ..consts import REPO_TYPES
-from ..utils.get_artifactory_info import get_artifactory_info
+from ..utils.get_artifactory_info import get_repos
 from ..utils.setup_pluginbase import get_policy, setup_pluginbase
 
 LOG = logging.getLogger(__name__)
@@ -33,8 +33,7 @@ def policies(ctx, policies_path, repo, repo_type):
     """Prints out a JSON list of all repos and policy descriptions."""
     LOG.debug('Passed args: %s, %s, %s, %s', ctx, policies_path, repo, repo_type)
 
-    # pylint: disable=unused-variable
-    storage_info, selected_repos = get_artifactory_info(repo_names=repo, repo_type=repo_type)
+    selected_repos = get_repos(repo_names=repo, repo_type=repo_type)
 
     plugin_source = setup_pluginbase(extra_policies_path=policies_path)
     policy_list = [get_description(plugin_source, r) for r in selected_repos]

--- a/src/lavatory/commands/purge.py
+++ b/src/lavatory/commands/purge.py
@@ -6,7 +6,7 @@ import click
 
 from ..consts import REPO_TYPES
 from ..utils.artifactory import Artifactory
-from ..utils.get_artifactory_info import get_artifactory_info
+from ..utils.get_artifactory_info import get_repos, get_storage
 from ..utils.performance import get_performance_report
 from ..utils.setup_pluginbase import get_policy, setup_pluginbase
 
@@ -38,7 +38,8 @@ def purge(ctx, dryrun, policies_path, default, repo, repo_type):  # pylint: disa
     """Deletes artifacts based on retention policies."""
     LOG.debug('Passed args: %s, %s, %s, %s, %s, %s', ctx, dryrun, policies_path, default, repo, repo_type)
 
-    storage_info, selected_repos = get_artifactory_info(repo_names=repo, repo_type=repo_type)
+    storage_info = get_storage(repo_names=repo, repo_type=repo_type)
+    selected_repos = get_repos(repo_names=repo, repo_type=repo_type)
 
     apply_purge_policies(selected_repos, policies_path=policies_path, dryrun=dryrun, default=default)
     generate_purge_report(selected_repos, storage_info)
@@ -76,6 +77,9 @@ def generate_purge_report(purged_repos, before_purge_data):
         purged_repos (list): List of repos that had policy applied.
         before_purge_data (dict): Data on the state of Artifactory before purged artifacts
     """
+    if not before_purge_data:
+        LOG.info('User does not have "Admin Privileges" to generate performance details.')
+        return
     LOG.info("Purging Performance:")
     artifactory = Artifactory(repo_name=None)
     after_purge_data = artifactory.repos()

--- a/src/lavatory/commands/stats.py
+++ b/src/lavatory/commands/stats.py
@@ -22,7 +22,7 @@ def stats(ctx, repo):
 
     storage = get_storage(repo_names=repo, repo_type='any')
     if not storage:
-        click.echo('User does not have "Admin Privileges" to generate statistics.')
+        LOG.info('User does not have "Admin Privileges" to generate statistics.')
         return
 
     repositories = get_repos(repo_names=repo, repo_type='any')

--- a/src/lavatory/commands/stats.py
+++ b/src/lavatory/commands/stats.py
@@ -3,7 +3,7 @@ import logging
 
 import click
 
-from ..utils.get_artifactory_info import get_artifactory_info
+from ..utils.get_artifactory_info import get_repos, get_storage
 
 LOG = logging.getLogger(__name__)
 
@@ -19,9 +19,14 @@ LOG = logging.getLogger(__name__)
 def stats(ctx, repo):
     """Get statistics of repos."""
     LOG.debug('Passed args: %s, %s.', ctx, repo)
-    storage, keys = get_artifactory_info(repo_names=repo, repo_type='any')
 
-    for repository in keys:
+    storage = get_storage(repo_names=repo, repo_type='any')
+    if not storage:
+        click.echo('User does not have "Admin Privileges" to generate statistics.')
+        return
+
+    repositories = get_repos(repo_names=repo, repo_type='any')
+    for repository in repositories:
         repo = storage.get(repository)
         if repo is None:
             LOG.error('Repo name %s does not exist.', repository)

--- a/src/lavatory/utils/get_artifactory_info.py
+++ b/src/lavatory/utils/get_artifactory_info.py
@@ -1,7 +1,35 @@
 """Helper method for getting artifactory information."""
 import logging
 
+import requests
+
 from .artifactory import Artifactory
+
+
+def _artifactory(artifactory=None, repo_names=None):
+    if not artifactory:
+        artifactory = Artifactory(repo_name=repo_names)
+    return artifactory
+
+
+def get_storage(repo_names=None, repo_type=None):
+    artifactory = _artifactory(repo_names=repo_names)
+    storage_info = []
+    try:
+        storage_info = artifactory.repos(repo_type=repo_type)
+    except requests.exceptions.HTTPError:
+        logging.warning('Account is not an admin and may not be able to get storage details.')
+    logging.debug('Storage info: %s', storage_info)
+    return storage_info
+
+
+def get_repos(repo_names=None, repo_type='local'):
+    repos = []
+    if repo_names:
+        repos = repo_names
+    else:
+        repos = get_storage(repo_names=repo_names, repo_type=repo_type)
+    return repos
 
 
 def get_artifactory_info(repo_names=None, repo_type='local'):

--- a/src/lavatory/utils/get_artifactory_info.py
+++ b/src/lavatory/utils/get_artifactory_info.py
@@ -5,6 +5,8 @@ import requests
 
 from .artifactory import Artifactory
 
+LOG = logging.getLogger(__name__)
+
 
 def _artifactory(artifactory=None, repo_names=None):
     if not artifactory:
@@ -18,8 +20,8 @@ def get_storage(repo_names=None, repo_type=None):
     try:
         storage_info = artifactory.repos(repo_type=repo_type)
     except requests.exceptions.HTTPError:
-        logging.warning('Account is not an admin and may not be able to get storage details.')
-    logging.debug('Storage info: %s', storage_info)
+        LOG.warning('Account is not an admin and may not be able to get storage details.')
+    LOG.debug('Storage info: %s', storage_info)
     return storage_info
 
 
@@ -51,7 +53,7 @@ def get_artifactory_info(repo_names=None, repo_type='local'):
     else:
         keys = storage_info.keys()
 
-    logging.debug('Storage info: %s', storage_info)
-    logging.debug('Keys: %s', keys)
+    LOG.debug('Storage info: %s', storage_info)
+    LOG.debug('Keys: %s', keys)
 
     return storage_info, keys

--- a/tests/commands/test_policies.py
+++ b/tests/commands/test_policies.py
@@ -21,8 +21,8 @@ def test_get_description(mock_get_policy):
     assert 'policy_description' in description.keys()
 
 
-@mock.patch('lavatory.commands.policies.get_artifactory_info')
-def test_policies(mock_get_art_info, runner):
+@mock.patch('lavatory.commands.policies.get_repos')
+def test_policies(mock_get_repos, runner):
     data = {
         'test-local': {
             'repoKey': 'test-local',
@@ -35,8 +35,7 @@ def test_policies(mock_get_art_info, runner):
             'percentage': '8.05%'
         }
     }
-    key = data.keys()
-    mock_get_art_info.return_value = data, key
+    mock_get_repos.return_value = data
     result_one = runner.invoke(policies)
 
     assert result_one.exit_code == 0

--- a/tests/commands/test_purge.py
+++ b/tests/commands/test_purge.py
@@ -33,10 +33,11 @@ def runner():
     return CliRunner()
 
 
-@mock.patch('lavatory.commands.purge.get_artifactory_info')
+@mock.patch('lavatory.commands.purge.get_storage')
+@mock.patch('lavatory.commands.purge.get_repos')
 @mock.patch('lavatory.commands.purge.apply_purge_policies')
 @mock.patch('lavatory.commands.purge.generate_purge_report')
-def test_policies(mock_purge_report, mock_purge_policies, mock_get_art_info, runner):
+def test_policies(mock_purge_report, mock_purge_policies, mock_get_repos, mock_get_storage, runner):
     data = {
         'test-local': {
             'repoKey': 'test-local',
@@ -49,8 +50,8 @@ def test_policies(mock_purge_report, mock_purge_policies, mock_get_art_info, run
             'percentage': '8.05%'
         }
     }
-    key = data.keys()
-    mock_get_art_info.return_value = data, key
+    mock_get_repos.return_value = data
+    mock_get_storage.return_value = True
     mock_purge_report.return_value = True
     mock_purge_policies.return_value = True
     result_one = runner.invoke(purge)

--- a/tests/commands/test_stats.py
+++ b/tests/commands/test_stats.py
@@ -33,6 +33,4 @@ def test_command_stats(mock_get_repos, mock_get_storage, runner):
     result_two = runner.invoke(stats)
 
     assert result_one.exit_code == 0
-    assert 'does not have' in result_one.output
     assert result_two.exit_code == 0
-    assert 'does not have' in result_two.output

--- a/tests/commands/test_stats.py
+++ b/tests/commands/test_stats.py
@@ -12,8 +12,9 @@ def runner():
     return CliRunner()
 
 
-@mock.patch('lavatory.commands.stats.get_artifactory_info')
-def test_command_stats(mock_artifactory, runner):
+@mock.patch('lavatory.commands.stats.get_storage')
+@mock.patch('lavatory.commands.stats.get_repos')
+def test_command_stats(mock_get_repos, mock_get_storage, runner):
     data = {
         'test-local': {
             'repoKey': 'test-local',
@@ -26,12 +27,12 @@ def test_command_stats(mock_artifactory, runner):
             'percentage': '8.05%'
         }
     }
-    key = data.keys()
-    mock_artifactory.return_value = data, key
+    mock_get_repos.return_value = data
+    mock_get_storage.return_value = {}
     result_one = runner.invoke(stats, ['--repo', 'test-local'])
     result_two = runner.invoke(stats)
 
     assert result_one.exit_code == 0
-    assert result_one.output == 'Done.\n'
+    assert 'does not have' in result_one.output
     assert result_two.exit_code == 0
-    assert result_two.output == 'Done.\n'
+    assert 'does not have' in result_two.output

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,lint
+envlist = py35,py36,py37,lint
 skip_missing_interpreters = True
 
 [pytest]


### PR DESCRIPTION
This attempts to address the output when `lavatory` is run with an account that is not contain `Admin Privileges`.

Account with admin access
```
+ lavatory -v policies
[DEBUG] lavatory.commands.policies Passed args: <click.core.Context object at 0x7f89a8d26f28>, None, (), local
[DEBUG] lavatory.utils.artifactory Storage info data: {'storageSummary': {'binariesSummary': {'binariesCount': '0', 'binariesSize': '0 bytes', 'artifactsSize': '0 bytes', 'optimization': 'N/A', 'itemsCount': '0', 'artifactsCount': '0'}, 'fileStoreSummary': {'storageType': 'file-system', 'storageDirectory': '/opt/jfrog/artifactory/data/filestore', 'totalSpace': '459.62 GB', 'usedSpace': '83.59 GB (18.19%)', 'freeSpace': '376.03 GB (81.81%)'}, 'repositoriesSummaryList': [{'repoKey': 'docker-local', 'repoType': 'LOCAL', 'foldersCount': 0, 'filesCount': 0, 'usedSpace': '0 bytes', 'itemsCount': 0, 'packageType': 'Docker', 'percentage': 'N/A'}, {'repoKey': 'auto-trashcan', 'repoType': 'NA', 'foldersCount': 0, 'filesCount': 0, 'usedSpace': '0 bytes', 'itemsCount': 0, 'packageType': 'NA', 'percentage': 'N/A'}, {'repoKey': 'docker-remote-cache', 'repoType': 'CACHE', 'foldersCount': 0, 'filesCount': 0, 'usedSpace': '0 bytes', 'itemsCount': 0, 'packageType': 'Docker', 'percentage': 'N/A'}, {'repoKey': 'bintray-docker-remote-cache', 'repoType': 'CACHE', 'foldersCount': 0, 'filesCount': 0, 'usedSpace': '0 bytes', 'itemsCount': 0, 'packageType': 'Docker', 'percentage': 'N/A'}, {'repoKey': 'docker', 'repoType': 'VIRTUAL', 'foldersCount': 0, 'filesCount': 0, 'usedSpace': '0 bytes', 'itemsCount': 0, 'packageType': 'Docker', 'percentage': 'N/A'}, {'repoKey': 'TOTAL', 'repoType': 'NA', 'foldersCount': 0, 'filesCount': 0, 'usedSpace': '0 bytes', 'itemsCount': 0}]}, 'binariesSummary': {'binariesCount': '0', 'binariesSize': '0 bytes', 'artifactsSize': '0 bytes', 'optimization': 'N/A', 'itemsCount': '0', 'artifactsCount': '0'}, 'fileStoreSummary': {'storageType': 'file-system', 'storageDirectory': '/opt/jfrog/artifactory/data/filestore', 'totalSpace': '459.62 GB', 'usedSpace': '83.59 GB (18.19%)', 'freeSpace': '376.03 GB (81.81%)'}, 'repositoriesSummaryList': [{'repoKey': 'docker-local', 'repoType': 'LOCAL', 'foldersCount': 0, 'filesCount': 0, 'usedSpace': '0 bytes', 'itemsCount': 0, 'packageType': 'Docker', 'percentage': 'N/A'}, {'repoKey': 'auto-trashcan', 'repoType': 'NA', 'foldersCount': 0, 'filesCount': 0, 'usedSpace': '0 bytes', 'itemsCount': 0, 'packageType': 'NA', 'percentage': 'N/A'}, {'repoKey': 'docker-remote-cache', 'repoType': 'CACHE', 'foldersCount': 0, 'filesCount': 0, 'usedSpace': '0 bytes', 'itemsCount': 0, 'packageType': 'Docker', 'percentage': 'N/A'}, {'repoKey': 'bintray-docker-remote-cache', 'repoType': 'CACHE', 'foldersCount': 0, 'filesCount': 0, 'usedSpace': '0 bytes', 'itemsCount': 0, 'packageType': 'Docker', 'percentage': 'N/A'}, {'repoKey': 'docker', 'repoType': 'VIRTUAL', 'foldersCount': 0, 'filesCount': 0, 'usedSpace': '0 bytes', 'itemsCount': 0, 'packageType': 'Docker', 'percentage': 'N/A'}, {'repoKey': 'TOTAL', 'repoType': 'NA', 'foldersCount': 0, 'filesCount': 0, 'usedSpace': '0 bytes', 'itemsCount': 0}]}
[DEBUG] lavatory.utils.artifactory Skipping repo auto-trashcan, not of type local
[DEBUG] lavatory.utils.artifactory Skipping repo docker-remote-cache, not of type local
[DEBUG] lavatory.utils.artifactory Skipping repo bintray-docker-remote-cache, not of type local
[DEBUG] lavatory.utils.artifactory Skipping repo docker, not of type local
[DEBUG] lavatory.utils.get_artifactory_info Storage info: {'docker-local': {'repoKey': 'docker-local', 'repoType': 'LOCAL', 'foldersCount': 0, 'filesCount': 0, 'usedSpace': '0 bytes', 'itemsCount': 0, 'packageType': 'Docker', 'percentage': 'N/A'}}
[INFO] lavatory.utils.setup_pluginbase Searching for policies in ['/home/saviles/data/git/github/lavatory/src/lavatory/utils/../policies']
[DEBUG] lavatory.utils.setup_pluginbase Policies found: ['default']
[INFO] lavatory.utils.setup_pluginbase No policy found for docker-local. Applying Default
[INFO] lavatory.commands.policies docker-local - Default Policy. Keeps the last 5 artifacts from each project
[{"repo": "docker-local", "policy_description": "Default Policy. Keeps the last 5 artifacts from each project"}]
+ lavatory stats --repo=docker
[INFO] lavatory.commands.stats Repo Name: docker.
[INFO] lavatory.commands.stats Repo Type: VIRTUAL - Docker.
[INFO] lavatory.commands.stats Repo Used Space: 0 bytes - N/A of total used space.
[INFO] lavatory.commands.stats Repo Folders 0, Files 0. Total items count: 0.
[INFO] lavatory.commands.stats -------------------------
Done.
+ lavatory purge --policies-path=/home/saviles/retention-policies/
[INFO] lavatory.utils.setup_pluginbase Searching for policies in ['/home/saviles/retention-policies/', '/home/saviles/data/git/github/lavatory/src/lavatory/utils/../policies']
[INFO] lavatory.commands.purge Applying retention policies to docker-local
[INFO] lavatory.utils.setup_pluginbase No policy found for docker-local. Applying Default
[INFO] lavatory.commands.purge Policy Docs: Default Policy. Keeps the last 5 artifacts from each project
[INFO] lavatory.utils.artifactory Searching for purgable artifacts with count based retention in docker-local.
[INFO] lavatory.utils.artifactory Running mode: DRYRUN
[INFO] lavatory.commands.purge Processed docker-local, Purged 0
[INFO] lavatory.commands.purge Purging Performance:
[INFO] lavatory.utils.performance docker-local size: 0 bytes; reduction: storage 0 bytes (0.0%), files 0 (0.0%)
[INFO] lavatory.commands.purge Success.
```

Account without admin access
```
+ lavatory -v policies
[DEBUG] lavatory.commands.policies Passed args: <click.core.Context object at 0x7f78fbb36fd0>, None, (), local
[WARNING] lavatory.utils.get_artifactory_info Account is not an admin and may not be able to get storage details.
[DEBUG] lavatory.utils.get_artifactory_info Storage info: []
[INFO] lavatory.utils.setup_pluginbase Searching for policies in ['/home/saviles/data/git/github/lavatory/src/lavatory/utils/../policies']
[DEBUG] lavatory.utils.setup_pluginbase Policies found: ['default']
[]
+ lavatory stats --repo=docker
[WARNING] lavatory.utils.get_artifactory_info Account is not an admin and may not be able to get storage details.
User does not have "Admin Privileges" to generate statistics.
+ lavatory purge --policies-path=/home/saviles/retention-policies/
[WARNING] lavatory.utils.get_artifactory_info Account is not an admin and may not be able to get storage details.
[WARNING] lavatory.utils.get_artifactory_info Account is not an admin and may not be able to get storage details.
[INFO] lavatory.utils.setup_pluginbase Searching for policies in ['/home/saviles/retention-policies/', '/home/saviles/data/git/github/lavatory/src/lavatory/utils/../policies']
[INFO] lavatory.commands.purge Applying retention policies to 
[INFO] lavatory.commands.purge User does not have "Admin Privileges" to generate performance details.
[INFO] lavatory.commands.purge Success.
```

This should fix and address issue #32.