### PR TITLE
fix: Broken version command

### DIFF
--- a/src/lavatory/__main__.py
+++ b/src/lavatory/__main__.py
@@ -1,10 +1,8 @@
 """Main entry point."""
 import logging
-import pprint
 
 import click
 import coloredlogs
-import pip
 
 from .commands.policies import policies
 from .commands.purge import purge
@@ -31,18 +29,9 @@ def root(ctx, verbose):
 @root.command()
 def version():
     """Print version information."""
-    for package_info in pip.commands.show.search_packages_info([__package__]):
-        LOG.debug('Full package info: %s', pprint.pformat(package_info))
-
-        name = package_info['name']
-        if name != __package__:
-            LOG.debug('This is not the package you are looking for: %s', name)
-            continue
-
-        click.echo(package_info['version'])
-        break
-    else:
-        raise KeyError('Could not find {0}'.format(__package__))
+    import pkg_resources
+    lavatory_version = pkg_resources.get_distribution('lavatory').version
+    click.echo(lavatory_version)
 
 
 root.add_command(policies)


### PR DESCRIPTION
This fixes the broken `version` command.

From
```
$ lavatory version
Traceback (most recent call last):
  File "/home/saviles/.local/share/virtualenvs/tmp-XVr6zr33/bin/lavatory", line 11, in <module>
    sys.exit(root())
  File "/home/saviles/.local/share/virtualenvs/tmp-XVr6zr33/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/saviles/.local/share/virtualenvs/tmp-XVr6zr33/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/saviles/.local/share/virtualenvs/tmp-XVr6zr33/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/saviles/.local/share/virtualenvs/tmp-XVr6zr33/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/saviles/.local/share/virtualenvs/tmp-XVr6zr33/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/saviles/.local/share/virtualenvs/tmp-XVr6zr33/lib/python3.7/site-packages/lavatory/__main__.py", line 34, in version
    for package_info in pip.commands.show.search_packages_info([__package__]):
AttributeError: module 'pip' has no attribute 'commands'
```

To

```
$ lavatory version
1.1.3.dev6
```