### PR TITLE
atifactory: make certs bundle path configurable

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -74,6 +74,23 @@ provided, Lavatory will run against all repos in Artifactory.
 By default, Lavatory runs in drymode. Must include ``--nodryrun`` in order to
 actually delete Artifacts
 
+Configure SSL
+~~~~~~~~~~~~~
+
+When HTTPS Artifactory URL is provided, Lavatory uses ``certifi`` to get the
+list of trusted certificates.
+
+If your server's certificate is not signed by any of certifi's authorities,
+you can either update the certifi's list whose file system path can be retrieved
+by the following command:
+
+::
+
+    python -c "import certifi; print(certifi.where())"
+
+or you can instruct Lavatory to use your own CA bundle file path by setting
+the environment variable ``LAVATORY_CERTBUNDLE_PATH``.
+
 CLI Help
 --------
 

--- a/src/lavatory/utils/artifactory.py
+++ b/src/lavatory/utils/artifactory.py
@@ -1,4 +1,5 @@
 """Artifactory purger module."""
+import os
 import base64
 import datetime
 import logging
@@ -29,7 +30,7 @@ class Artifactory:
         self.artifactory.artifactory_url = self.api_url
         self.artifactory.username = self.credentials['artifactory_username']
         self.artifactory.password = base64.encodebytes(bytes(self.credentials['artifactory_password'], 'utf-8'))
-        self.artifactory.certbundle = certifi.where()
+        self.artifactory.certbundle = os.getenv('LAVATORY_CERTBUNDLE_PATH', certifi.where())
 
     def repos(self, repo_type='local'):
         """


### PR DESCRIPTION
Sometimes we find a big corporation issuing its own internal
certificates which we want to trust.