### PR TITLE
bubble up import errors from loading the actual plugins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests
 humanfriendly
 party
 pluginbase
+django

--- a/src/lavatory/utils/setup_pluginbase.py
+++ b/src/lavatory/utils/setup_pluginbase.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import pathlib
+import re
 
 from pluginbase import PluginBase
 
@@ -51,7 +52,10 @@ def get_policy(plugin_source, repository, default=True):
     policy_name = repository.replace("-", "_")
     try:
         policy = plugin_source.load_plugin(policy_name)
-    except ImportError:
+    except ImportError as err:
+        # bubble up import errors from the actual loading of existing plugins
+        if not re.match(r'^No module named \'pluginbase\..+\.%s\'$' % policy_name, str(err)):
+            raise err
         if default:
             LOG.info("No policy found for %s. Applying Default", repository)
             policy = plugin_source.load_plugin('default')


### PR DESCRIPTION
I noticed that all my repos were silently getting filtered through the default because i had import errors in my plugin files.
This now throws if you have import errors in your actual plugin files.