### PR TITLE
env var to skip cert verify for dev contexts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests
 humanfriendly
 party
 pluginbase
+django

--- a/src/lavatory/utils/artifactory.py
+++ b/src/lavatory/utils/artifactory.py
@@ -30,7 +30,8 @@ class Artifactory:
         self.artifactory.artifactory_url = self.api_url
         self.artifactory.username = self.credentials['artifactory_username']
         self.artifactory.password = base64.encodebytes(bytes(self.credentials['artifactory_password'], 'utf-8'))
-        self.artifactory.certbundle = os.getenv('LAVATORY_CERTBUNDLE_PATH', certifi.where())
+        skip_verify = int(os.getenv('LAVATORY_SKIP_CERT_VERIFY', '1'))
+        self.artifactory.certbundle = False if skip_verify else os.getenv('LAVATORY_CERTBUNDLE_PATH', certifi.where())
 
     def repos(self, repo_type='local'):
         """


### PR DESCRIPTION
We have a dev artifactory instance, and the server's certs don't pass verify. 

You can do this with the vanilla requests library by setting the `CURL_CA_BUNDLE` environment variable to an empty string. However, the artifactory class forces verify by passing a bundle by default. I would like to be able to override this behavior with an environment variable.